### PR TITLE
update to href to match deployment routes

### DIFF
--- a/app/GoodPortfolio.js
+++ b/app/GoodPortfolio.js
@@ -19,7 +19,7 @@ export default function GoodPortfolio() {
 
                     {/* Done */}
                     <div className="border-2 rounded-lg bg-white shadow-lg p-3 w-auto">
-                        <Link className="" href="/pages/done">
+                        <Link href="/pages/Done">
                             <Image
                                 className="bg-white w-full"
                                 width={150}
@@ -32,7 +32,7 @@ export default function GoodPortfolio() {
 
                     {/* Music City Pressure */}
                     <div className="border-2 rounded-lg bg-white shadow-lg p-3 w-auto">
-                        <Link className="" href="/pages/musiccitypressure">
+                        <Link href="/pages/MusicCityPressure">
                             <Image
                                 className="bg-white w-full"
                                 width={150}

--- a/app/pages/portfolio/page.js
+++ b/app/pages/portfolio/page.js
@@ -40,7 +40,7 @@ export default function Page() {
                                 </div>
 
                                 <div className="flex justify-between">
-                                    <Link href="/pages/done" className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+                                    <Link href="/pages/Done" className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
                                         Demo Project
                                         {/* <svg aria-hidden="true" className="w-4 h-4 ml-2 -mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path></svg> */}
                                     </Link>
@@ -102,7 +102,7 @@ export default function Page() {
                                     <p className="pb-4 font-normal text-gray-700 dark:text-gray-300">Music City Pressure is a back-end project designed to facilitate the scheduling and tracking of home power washing appointments. It empowers customers by providing them with essential information and tools to efficiently manage their appointments. The project encompasses three distinct views to enhance user experience and functionality.</p>
                                 </div>
                                 <div className="flex justify-between">
-                                    <Link href="/pages/musiccitypressure" className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+                                    <Link href="/pages/MusicCityPressure" className="inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
                                         Demo Project
                                         <svg aria-hidden="true" className="w-4 h-4 ml-2 -mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path></svg>
                                     </Link>


### PR DESCRIPTION
update href routes and `done` and`musiccitypressure` folders to match deployment logs.
The logged rountes for done and `musiccitypressure` are captiolized below
```py
Route (app)                                Size     First Load JS
┌ ○ /                                      1.07 kB        88.6 kB
├ ○ /favicon.ico                           0 B                0 B
├ ○ /pages                                 174 B          82.1 kB
├ ○ /pages/aboutme                         137 B          77.3 kB
├ ○ /pages/Done                            177 B            83 kB
├ ○ /pages/MusicCityPressure               177 B            83 kB
└ ○ /pages/portfolio                       185 B          87.8 kB
```

This has been a issue with React for me.  Sometimes if you change a component name say from Done to done...it will not take in the code.  This might be the main reason for the issue I have encountered.  updating the href for all links pointing to `pages/done` or `pages/musiccitypressure` to the new folder updates `pages/Done` and `pages/MusicCityPressure` like in the logs.